### PR TITLE
Update auto build, turn on lint and make lint pass.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 _build
 *.pyc
+.env
+build*
+bundles

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,425 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=2
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,import-error
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9_]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9_]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=r,g,b,i,j,k,n,ex,Run,_
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=11
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,30 @@
-# Travis CI configuration for automated .mpy file generation.
-# Author: Tony DiCola
-# License: Public Domain
-# This configuration will work with Travis CI (travis-ci.org) to automacially
-# build .mpy files for CircuitPython when a new tagged release is created.  This
-# file is relatively generic and can be shared across multiple repositories by
-# following these steps:
-#   1. Copy this file into a .travis.yml file in the root of the repository.
-#   2. Change the deploy > file section below to list each of the .mpy files
-#      that should be generated.  The config will automatically look for
-#      .py files with the same name as the source for generating the .mpy files.
-#      Note that the .mpy extension should be lower case!
-#   3. Commit the .travis.yml file and push it to GitHub.
-#   4. Go to travis-ci.org and find the repository (it needs to be setup to access
-#      your github account, and your github account needs access to write to the
-#      repo).  Flip the 'ON' switch on for Travis and the repo, see the Travis
-#      docs for more details: https://docs.travis-ci.com/user/getting-started/
-#   5. Get a GitHub 'personal access token' which has at least 'public_repo' or
-#      'repo' scope: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
-#      Keep this token safe and secure!  Anyone with the token will be able to
-#      access and write to your GitHub repositories.  Travis will use the token
-#      to attach the .mpy files to the release.
-#   6. In the Travis CI settings for the repository that was enabled find the
-#      environment variable editing page: https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
-#      Add an environment variable named GITHUB_TOKEN and set it to the value
-#      of the GitHub personal access token above.  Keep 'Display value in build
-#      log' flipped off.
-#   7. That's it!  Tag a release and Travis should go to work to add .mpy files
-#      to the release.  It takes about a 2-3 minutes for a worker to spin up,
-#      build mpy-cross, and add the binaries to the release.
-language: generic
+# This is a common .travis.yml for generating library release zip files for
+# CircuitPython library releases using circuitpython-build-tools.
+# See https://github.com/adafruit/circuitpython-build-tools for detailed setup
+# instructions.
 
-sudo: true
+dist: trusty
+sudo: false
+language: python
+python:
+    - "3.6"
+
+cache:
+    pip: true
 
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
-  file:
-  - "adafruit_bme280.mpy"
+  file_glob: true
+  file: bundles/*
   skip_cleanup: true
   on:
     tags: true
 
-before_install:
-- sudo apt-get -yqq update
-- sudo apt-get install -y build-essential git python python-pip
-- git clone https://github.com/adafruit/circuitpython.git -b 2.x
-- make -C circuitpython/mpy-cross
-- export PATH=$PATH:$PWD/circuitpython/mpy-cross/
-- sudo pip install shyaml
+install:
+  - pip install pylint circuitpython-travis-build-tools
 
-before_deploy:
-- shyaml get-values deploy.file < .travis.yml | sed 's/.mpy/.py/' | xargs -L1 mpy-cross
+script:
+  - pylint adafruit_bme280.py
+  - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name examples/*.py)
+  - circuitpython-build-bundles --filename_prefix adafruit-circuitpython-bme280 --library_location .

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -27,169 +27,179 @@ CircuitPython driver from BME280 Temperature, Humidity and Barometic Pressure se
 
 * Author(s): ladyada
 """
-import time, math
+import math
+import time
 from micropython import const
 try:
     import struct
 except ImportError:
     import ustruct as struct
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BME280.git"
+
 #    I2C ADDRESS/BITS/SETTINGS
 #    -----------------------------------------------------------------------
 _BME280_ADDRESS = const(0x77)
-_BME280_CHIPID  = const(0x60)
+_BME280_CHIPID = const(0x60)
 
-_BME280_REGISTER_CHIPID  = const(0xD0)
-_BME280_REGISTER_DIG_T1  = const(0x88)
-_BME280_REGISTER_DIG_H1  = const(0xA1)
-_BME280_REGISTER_DIG_H2  = const(0xE1)
-_BME280_REGISTER_DIG_H3  = const(0xE3)
-_BME280_REGISTER_DIG_H4  = const(0xE4)
-_BME280_REGISTER_DIG_H5  = const(0xE5)
-_BME280_REGISTER_DIG_H6  = const(0xE7)
+_BME280_REGISTER_CHIPID = const(0xD0)
+_BME280_REGISTER_DIG_T1 = const(0x88)
+_BME280_REGISTER_DIG_H1 = const(0xA1)
+_BME280_REGISTER_DIG_H2 = const(0xE1)
+_BME280_REGISTER_DIG_H3 = const(0xE3)
+_BME280_REGISTER_DIG_H4 = const(0xE4)
+_BME280_REGISTER_DIG_H5 = const(0xE5)
+_BME280_REGISTER_DIG_H6 = const(0xE7)
 
-_BME280_REGISTER_SOFTRESET  = const(0xE0)
+_BME280_REGISTER_SOFTRESET = const(0xE0)
 _BME280_REGISTER_CTRL_HUM = const(0xF2)
 _BME280_REGISTER_STATUS = const(0xF3)
 _BME280_REGISTER_CTRL_MEAS = const(0xF4)
 _BME280_REGISTER_CONFIG = const(0xF5)
-_BME280_REGISTER_PRESSUREDATA  = const(0xF7)
+_BME280_REGISTER_PRESSUREDATA = const(0xF7)
 _BME280_REGISTER_TEMPDATA = const(0xFA)
 _BME280_REGISTER_HUMIDDATA = const(0xFD)
 
 _BME280_PRESSURE_MIN_HPA = const(300)
 _BME280_PRESSURE_MAX_HPA = const(1100)
-_BME280_HUMIDITY_MIN     = const(0)
-_BME280_HUMIDITY_MAX     = const(100)
+_BME280_HUMIDITY_MIN = const(0)
+_BME280_HUMIDITY_MAX = const(100)
 
 class Adafruit_BME280:
     """Driver from BME280 Temperature, Humidity and Barometic Pressure sensor"""
     def __init__(self):
-        """Check the BME280 was found, read the coefficients and enable the sensor for continuous reads"""
+        """Check the BME280 was found, read the coefficients and enable the sensor for continuous
+           reads"""
         # Check device ID.
-        id = self._read_byte(_BME280_REGISTER_CHIPID)
-        if _BME280_CHIPID != id:
+        chip_id = self._read_byte(_BME280_REGISTER_CHIPID)
+        if _BME280_CHIPID != chip_id:
             raise RuntimeError('Failed to find BME280! Chip ID 0x%x' % id)
         self._write_register_byte(_BME280_REGISTER_SOFTRESET, 0xB6)
         time.sleep(0.5)
         self._read_coefficients()
-        self.seaLevelhPa = 1013.25
+        self.sea_level_pressure = 1013.25
         """Pressure in hectoPascals at sea level. Used to calibrate `altitude`."""
-        self._write_register_byte(_BME280_REGISTER_CTRL_HUM, 0x03)  # turn on humidity oversample 16x
+        # turn on humidity oversample 16x
+        self._write_register_byte(_BME280_REGISTER_CTRL_HUM, 0x03)
+        self._t_fine = None
 
-    @property
-    def temperature(self):
-        """The compensated temperature in degrees celsius."""
+    def _read_temperature(self):
         # perform one measurement
         self._write_register_byte(_BME280_REGISTER_CTRL_MEAS, 0xFE) # high res, forced mode
 
         # Wait for conversion to complete
-        while (self._read_byte(_BME280_REGISTER_STATUS) & 0x08):
+        while self._read_byte(_BME280_REGISTER_STATUS) & 0x08:
             time.sleep(0.002)
-        UT = self._read24(_BME280_REGISTER_TEMPDATA) / 16  # lowest 4 bits get dropped
+        raw_temperature = self._read24(_BME280_REGISTER_TEMPDATA) / 16  # lowest 4 bits get dropped
         #print("raw temp: ", UT)
 
-        var1 = (UT / 16384.0 - self.dig_T1 / 1024.0) * self.dig_T2
+        var1 = (raw_temperature / 16384.0 - self._temp_calib[0] / 1024.0) * self._temp_calib[1]
         #print(var1)
-        var2 = ((UT / 131072.0 - self.dig_T1 / 8192.0) * (
-            UT / 131072.0 - self.dig_T1 / 8192.0)) * self.dig_T3
+        var2 = ((raw_temperature / 131072.0 - self._temp_calib[0] / 8192.0) * (
+            raw_temperature / 131072.0 - self._temp_calib[0] / 8192.0)) * self._temp_calib[2]
         #print(var2)
 
-        self.t_fine = int(var1 + var2)
+        self._t_fine = int(var1 + var2)
         #print("t_fine: ", self.t_fine)
 
-        temp = (var1 + var2) / 5120.0
-        return temp
+    @property
+    def temperature(self):
+        """The compensated temperature in degrees celsius."""
+        self._read_temperature()
+        return self._t_fine / 5120.0
 
     @property
     def pressure(self):
         """The compensated pressure in hectoPascals."""
-        self.temperature  # force read of t_fine
+        self._read_temperature()
 
-        # Algorithm from the BME280 driver https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c
+        # Algorithm from the BME280 driver
+        # https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c
         adc = self._read24(_BME280_REGISTER_PRESSUREDATA) / 16  # lowest 4 bits get dropped
-        var1 = float(self.t_fine) / 2.0 - 64000.0
-        var2 = var1 * var1 * self.dig_P6 / 32768.0
-        var2 = var2 + var1 * self.dig_P5 * 2.0
-        var2 = var2 / 4.0 + self.dig_P4 * 65536.0
-        var3 = self.dig_P3 * var1 * var1 / 524288.0;
-        var1 = (var3 + self.dig_P2 * var1) / 524288.0
-        var1 = (1.0 + var1 / 32768.0) * self.dig_P1
+        var1 = float(self._t_fine) / 2.0 - 64000.0
+        var2 = var1 * var1 * self._pressure_calib[5] / 32768.0
+        var2 = var2 + var1 * self._pressure_calib[4] * 2.0
+        var2 = var2 / 4.0 + self._pressure_calib[3] * 65536.0
+        var3 = self._pressure_calib[2] * var1 * var1 / 524288.0
+        var1 = (var3 + self._pressure_calib[1] * var1) / 524288.0
+        var1 = (1.0 + var1 / 32768.0) * self._pressure_calib[0]
         if var1 == 0:
             return 0
         if var1:
-            p = 1048576.0 - adc
-            p = ((p - var2 / 4096.0) * 6250.0) / var1
-            var1 = self.dig_P9 * p * p / 2147483648.0
-            var2 = p * self.dig_P8 / 32768.0
-            p = p + (var1 + var2 + self.dig_P7) / 16.0
+            pressure = 1048576.0 - adc
+            pressure = ((pressure - var2 / 4096.0) * 6250.0) / var1
+            var1 = self._pressure_calib[8] * pressure * pressure / 2147483648.0
+            var2 = pressure * self._pressure_calib[7] / 32768.0
+            pressure = pressure + (var1 + var2 + self._pressure_calib[6]) / 16.0
 
-            p /= 100
-            if (p < _BME280_PRESSURE_MIN_HPA):  return _BME280_PRESSURE_MIN_HPA
-            if (p > _BME280_PRESSURE_MAX_HPA):  return _BME280_PRESSURE_MAX_HPA
-            return p
+            pressure /= 100
+            if pressure < _BME280_PRESSURE_MIN_HPA:
+                return _BME280_PRESSURE_MIN_HPA
+            if pressure > _BME280_PRESSURE_MAX_HPA:
+                return _BME280_PRESSURE_MAX_HPA
+            return pressure
         else:
             return _BME280_PRESSURE_MIN_HPA
 
     @property
     def humidity(self):
         """The relative humidity in RH %"""
-        self.temperature  # force read of t_fine
+        self._read_temperature()
         hum = self._read_register(_BME280_REGISTER_HUMIDDATA, 2)
         #print("Humidity data: ", hum)
         adc = float(hum[0] << 8 | hum[1])
         #print("adc:", adc)
 
-        # Algorithm from the BME280 driver https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c
-        var1 = float(self.t_fine) - 76800.0
+        # Algorithm from the BME280 driver
+        # https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c
+        var1 = float(self._t_fine) - 76800.0
         #print("var1 ", var1)
-        var2 = (self.dig_H4 * 64.0 + (self.dig_H5 / 16384.0) * var1)
+        var2 = (self._humidity_calib[3] * 64.0 + (self._humidity_calib[4] / 16384.0) * var1)
         #print("var2 ",var2)
         var3 = adc - var2
         #print("var3 ",var3)
-        var4 = self.dig_H2 / 65536.0
+        var4 = self._humidity_calib[1] / 65536.0
         #print("var4 ",var4)
-        var5 = (1.0 + (self.dig_H3 / 67108864.0) * var1)
+        var5 = (1.0 + (self._humidity_calib[2] / 67108864.0) * var1)
         #print("var5 ",var5)
-        var6 = 1.0 + (self.dig_H6 / 67108864.0) * var1 * var5
+        var6 = 1.0 + (self._humidity_calib[5] / 67108864.0) * var1 * var5
         #print("var6 ",var6)
         var6 = var3 * var4 * (var5 * var6)
-        humidity = var6 * (1.0 - self.dig_H1 * var6 / 524288.0)
+        humidity = var6 * (1.0 - self._humidity_calib[0] * var6 / 524288.0)
 
-        if (humidity > _BME280_HUMIDITY_MAX):
+        if humidity > _BME280_HUMIDITY_MAX:
             return _BME280_HUMIDITY_MAX
-        if (humidity < _BME280_HUMIDITY_MIN):
+        if humidity < _BME280_HUMIDITY_MIN:
             return _BME280_HUMIDITY_MIN
         # else...
         return humidity
 
     @property
     def altitude(self):
-        """The altitude based on current `pressure` versus the sea level pressure (`seaLevelhPa`) - which you must enter ahead of time)"""
-        p = self.pressure # in Si units for hPascal
-        return 44330 * (1.0 - math.pow(p / self.seaLevelhPa, 0.1903));
+        """The altitude based on current `pressure` versus the sea level pressure
+           (`sea_level_pressure`) - which you must enter ahead of time)"""
+        pressure = self.pressure # in Si units for hPascal
+        return 44330 * (1.0 - math.pow(pressure / self.sea_level_pressure, 0.1903))
 
     def _read_coefficients(self):
         """Read & save the calibration coefficients"""
         coeff = self._read_register(_BME280_REGISTER_DIG_T1, 24)
         coeff = list(struct.unpack('<HhhHhhhhhhhh', bytes(coeff)))
         coeff = [float(i) for i in coeff]
-        self.dig_T1, self.dig_T2, self.dig_T3 , self.dig_P1, self.dig_P2, self.dig_P3, self.dig_P4, self.dig_P5, self.dig_P6, self.dig_P7, self.dig_P8, self.dig_P9 = coeff
+        self._temp_calib = coeff[:3]
+        self._pressure_calib = coeff[3:]
 
-        self.dig_H1 = self._read_byte(_BME280_REGISTER_DIG_H1)
+        self._humidity_calib = [0]*6
+        self._humidity_calib[0] = self._read_byte(_BME280_REGISTER_DIG_H1)
         coeff = self._read_register(_BME280_REGISTER_DIG_H2, 7)
         coeff = list(struct.unpack('<hBBBBb', bytes(coeff)))
-        self.dig_H2 = float(coeff[0])
-        self.dig_H3 = float(coeff[1])
-        self.dig_H4 = float((coeff[2] << 4) |  (coeff[3] & 0xF))
-        self.dig_H5 = float(((coeff[3] & 0xF0) << 4) | coeff[4])
-        self.dig_H6 = float(coeff[5])
-        #print("%d %d %d" % (self.dig_T1, self.dig_T2, self.dig_T3))
-        #print("%d %d %d" % (self.dig_P1, self.dig_P2, self.dig_P3))
-        #print("%d %d %d" % (self.dig_P4, self.dig_P5, self.dig_P6))
-        #print("%d %d %d" % (self.dig_P7, self.dig_P8, self.dig_P9))
-        #print("%d %d %d" % (self.dig_H1, self.dig_H2, self.dig_H3))
-        #print("%d %d %d" % (self.dig_H4, self.dig_H5, self.dig_H6))
+        self._humidity_calib[1] = float(coeff[0])
+        self._humidity_calib[2] = float(coeff[1])
+        self._humidity_calib[3] = float((coeff[2] << 4) |  (coeff[3] & 0xF))
+        self._humidity_calib[4] = float(((coeff[3] & 0xF0) << 4) | coeff[4])
+        self._humidity_calib[5] = float(coeff[5])
 
     def _read_byte(self, register):
         """Read a byte register value and return it"""
@@ -203,7 +213,14 @@ class Adafruit_BME280:
             ret += float(b & 0xFF)
         return ret
 
+    def _read_register(self, register, length):
+        raise NotImplementedError()
+
+    def _write_register_byte(self, register, value):
+        raise NotImplementedError()
+
 class Adafruit_BME280_I2C(Adafruit_BME280):
+    """Driver for BME280 connected over I2C"""
     def __init__(self, i2c, address=_BME280_ADDRESS):
         import adafruit_bus_device.i2c_device as i2c_device
         self._i2c = i2c_device.I2CDevice(i2c, address)
@@ -223,6 +240,7 @@ class Adafruit_BME280_I2C(Adafruit_BME280):
             #print("$%02X <= 0x%02X" % (register, value))
 
 class Adafruit_BME280_SPI(Adafruit_BME280):
+    """Driver for BME280 connected over SPI"""
     def __init__(self, spi, cs, baudrate=100000):
         import adafruit_bus_device.spi_device as spi_device
         self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,7 +1,7 @@
-import board
-import digitalio
-import busio
 import time
+
+import board
+import busio
 import adafruit_bme280
 
 # Create library object using our Bus I2C port
@@ -14,7 +14,7 @@ bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 #bme280 = adafruit_bme280.Adafruit_BME280_SPI(spi, bme_cs)
 
 # change this to match the location's pressure (hPa) at sea level
-bme280.seaLevelhPa = 1013.25
+bme280.sea_level_pressure = 1013.25
 
 while True:
     print("\nTemperature: %0.1f C" % bme280.temperature)

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,1 @@
 requirements_file: requirements.txt
-


### PR DESCRIPTION
This changes the attribute seaLevelhPa to sea_level_pressure to
match python naming standards.