### PR TITLE
Add class attributes to allow more control over the sensor

### DIFF
--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -107,6 +107,7 @@ class STANDBY(Enum):
 
 class Adafruit_BME280:
     """Driver from BME280 Temperature, Humidity and Barometic Pressure sensor"""
+    # pylint: disable=too-many-instance-attributes
     def __init__(self):
         """Check the BME280 was found, read the coefficients and enable the sensor"""
         # Check device ID.

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -171,8 +171,8 @@ class Adafruit_BME280:
         return self._read_byte(_BME280_REGISTER_CONFIG)
 
     def _write_config(self):
-        normal_flag = False
         """Write the value to the config register in the device """
+        normal_flag = False
         if self._mode == MODE.NORMAL:
             #Writes to the config register may be ignored while in Normal mode
             normal_flag = True

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -85,8 +85,8 @@ OVERSCAN_X4 = const(0x03)
 OVERSCAN_X8 = const(0x04)
 OVERSCAN_X16 = const(0x05)
 
-_BME280_OVERSCANS = frozenset((OVERSCAN_DISABLE, OVERSCAN_X1, OVERSCAN_X2,
-                               OVERSCAN_X4, OVERSCAN_X8, OVERSCAN_X16))
+_BME280_OVERSCANS = {OVERSCAN_DISABLE:0, OVERSCAN_X1:1, OVERSCAN_X2:2,
+                     OVERSCAN_X4:4, OVERSCAN_X8:8, OVERSCAN_X16:16}
 
 """mode values"""
 MODE_SLEEP = const(0x00)
@@ -299,6 +299,30 @@ class Adafruit_BME280:
         ctrl_meas += (self.overscan_pressure << 2)
         ctrl_meas += self.mode
         return ctrl_meas
+
+    @property
+    def measurement_time_typical(self):
+        """Typical time in milliseconds required to complete a measurement in normal mode"""
+        meas_time_ms = 1.0
+        if self.overscan_temperature != OVERSCAN_DISABLE:
+            meas_time_ms += (2 * _BME280_OVERSCANS.get(self.overscan_temperature))
+        if self.overscan_pressure != OVERSCAN_DISABLE:
+            meas_time_ms += (2 * _BME280_OVERSCANS.get(self.overscan_pressure) + 0.5)
+        if self.overscan_humidity != OVERSCAN_DISABLE:
+            meas_time_ms += (2 * _BME280_OVERSCANS.get(self.overscan_humidity) + 0.5)
+        return meas_time_ms
+
+    @property
+    def measurement_time_max(self):
+        """Maximum time in milliseconds required to complete a measurement in normal mode"""
+        meas_time_ms = 1.25
+        if self.overscan_temperature != OVERSCAN_DISABLE:
+            meas_time_ms += (2.3 * _BME280_OVERSCANS.get(self.overscan_temperature))
+        if self.overscan_pressure != OVERSCAN_DISABLE:
+            meas_time_ms += (2.3 * _BME280_OVERSCANS.get(self.overscan_pressure) + 0.575)
+        if self.overscan_humidity != OVERSCAN_DISABLE:
+            meas_time_ms += (2.3 * _BME280_OVERSCANS.get(self.overscan_humidity) + 0.575)
+        return meas_time_ms
 
     @property
     def temperature(self):

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -171,6 +171,7 @@ class Adafruit_BME280:
         return self._read_byte(_BME280_REGISTER_CONFIG)
 
     def _write_config(self):
+        normal_flag = False
         """Write the value to the config register in the device """
         if self._mode == MODE.NORMAL:
             #Writes to the config register may be ignored while in Normal mode

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -143,8 +143,6 @@ class Adafruit_BME280:
             while self._get_status() & 0x08:
                 sleep(0.002)
         raw_temperature = self._read24(_BME280_REGISTER_TEMPDATA) / 16 # lowest 4 bits get dropped
-        if raw_temperature == 0x80000:  #0x80000 means the measurment was skipped
-            return
         #print("raw temp: ", UT)
         var1 = (raw_temperature / 16384.0 - self._temp_calib[0] / 1024.0) * self._temp_calib[1]
         #print(var1)
@@ -319,8 +317,6 @@ class Adafruit_BME280:
         # Algorithm from the BME280 driver
         # https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c
         adc = self._read24(_BME280_REGISTER_PRESSUREDATA) / 16  # lowest 4 bits get dropped
-        if adc == 0x80000:  #0x80000 means the measurement was skipped
-            return None
         var1 = float(self._t_fine) / 2.0 - 64000.0
         var2 = var1 * var1 * self._pressure_calib[5] / 32768.0
         var2 = var2 + var1 * self._pressure_calib[4] * 2.0
@@ -354,8 +350,6 @@ class Adafruit_BME280:
         """
         self._read_temperature()
         hum = self._read_register(_BME280_REGISTER_HUMIDDATA, 2)
-        if hum == 0x8000:   #0x8000 means the reading was skipped
-            return None
         #print("Humidity data: ", hum)
         adc = float(hum[0] << 8 | hum[1])
         #print("adc:", adc)

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -207,7 +207,7 @@ class Adafruit_BME280:
         return self._t_standby
 
     @standby_period.setter
-    def standy_period(self, value):
+    def standby_period(self, value):
         if not value in STANDBY:
             raise ValueError('Standby Period \'%s\' not supported' % (value))
         if self._t_standby == value:

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """
 `adafruit_bme280` - Adafruit BME280 - Temperature, Humidity & Barometic Pressure Sensor
-====================================================================================
+=========================================================================================
 
 CircuitPython driver from BME280 Temperature, Humidity and Barometic Pressure sensor
 

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -286,8 +286,6 @@ class Adafruit_BME280:
             config += (self._t_standby << 5)
         if self._iir_filter:
             config += (self._iir_filter << 2)
-        if isinstance(self, Adafruit_BME280_SPI):
-            config += 1     #enable SPI interface
         return config
 
     @property

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -198,8 +198,6 @@ class Adafruit_BME280:
     def mode(self, value):
         if not value in _BME280_MODES:
             raise ValueError('Mode \'%s\' not supported' % (value))
-        if self._mode == value:
-            return
         self._mode = value
         self._write_ctrl_meas()
 

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -233,7 +233,7 @@ class Adafruit_BME280:
         Temperature Oversampling
         Allowed values are set in the OVERSCAN enum class
         """
-        return self._overscan_humidity
+        return self._overscan_temperature
 
     @overscan_temperature.setter
     def overscan_temperature(self, value):

--- a/examples/bme280_normal_mode.py
+++ b/examples/bme280_normal_mode.py
@@ -1,0 +1,33 @@
+import time
+
+import board
+import busio
+import adafruit_bme280
+
+# Create library object using our Bus I2C port
+i2c = busio.I2C(board.SCL, board.SDA)
+bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+
+# OR create library object using our Bus SPI port
+#spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+#bme_cs = digitalio.DigitalInOut(board.D10)
+#bme280 = adafruit_bme280.Adafruit_BME280_SPI(spi, bme_cs)
+
+# change this to match the location's pressure (hPa) at sea level
+bme280.sea_level_pressure = 1013.25
+#refer to the BMP280 datasheet to understand what these do
+bme280.mode = adafruit_bme280.MODE.NORMAL
+bme280.standby_period = adafruit_bme280.STANDBY.TC_500
+bme280.iir_filter = adafruit_bme280.IIR_FILTER.X_16
+bme_280.overscan_pressure = adafruit_bme280.OVERSCAN.X_16
+bme_280.overscan_humidity = adafruit_bme280.OVERSCAN.X_1
+bme_280.overscan_temperature = adafruit_bme280.OVERSCAN.X_2
+#The sensor will need a moment to gather inital readings
+sleep(1)
+
+while True:
+    print("\nTemperature: %0.1f C" % bme280.temperature)
+    print("Humidity: %0.1f %%" % bme280.humidity)
+    print("Pressure: %0.1f hPa" % bme280.pressure)
+    print("Altitude = %0.2f meters" % bme280.altitude)
+    time.sleep(2)

--- a/examples/bme280_normal_mode.py
+++ b/examples/bme280_normal_mode.py
@@ -1,3 +1,8 @@
+"""
+Example showing how the BME280 library can be used to set the various
+parameters supported by the sensor.
+Refer to the BME280 datasheet to understand what these parameters do
+"""
 import time
 
 import board
@@ -15,13 +20,12 @@ bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
 # change this to match the location's pressure (hPa) at sea level
 bme280.sea_level_pressure = 1013.25
-#refer to the BMP280 datasheet to understand what these do
-bme280.mode = adafruit_bme280.MODE.NORMAL
-bme280.standby_period = adafruit_bme280.STANDBY.TC_500
-bme280.iir_filter = adafruit_bme280.IIR_FILTER.X_16
-bme280.overscan_pressure = adafruit_bme280.OVERSCAN.X_16
-bme280.overscan_humidity = adafruit_bme280.OVERSCAN.X_1
-bme280.overscan_temperature = adafruit_bme280.OVERSCAN.X_2
+bme280.mode = adafruit_bme280.MODE_NORMAL
+bme280.standby_period = adafruit_bme280.STANDBY_TC_500
+bme280.iir_filter = adafruit_bme280.IIR_FILTER_X16
+bme280.overscan_pressure = adafruit_bme280.OVERSCAN_X16
+bme280.overscan_humidity = adafruit_bme280.OVERSCAN_X1
+bme280.overscan_temperature = adafruit_bme280.OVERSCAN_X2
 #The sensor will need a moment to gather inital readings
 time.sleep(1)
 

--- a/examples/bme280_normal_mode.py
+++ b/examples/bme280_normal_mode.py
@@ -19,11 +19,11 @@ bme280.sea_level_pressure = 1013.25
 bme280.mode = adafruit_bme280.MODE.NORMAL
 bme280.standby_period = adafruit_bme280.STANDBY.TC_500
 bme280.iir_filter = adafruit_bme280.IIR_FILTER.X_16
-bme_280.overscan_pressure = adafruit_bme280.OVERSCAN.X_16
-bme_280.overscan_humidity = adafruit_bme280.OVERSCAN.X_1
-bme_280.overscan_temperature = adafruit_bme280.OVERSCAN.X_2
+bme280.overscan_pressure = adafruit_bme280.OVERSCAN.X_16
+bme280.overscan_humidity = adafruit_bme280.OVERSCAN.X_1
+bme280.overscan_temperature = adafruit_bme280.OVERSCAN.X_2
 #The sensor will need a moment to gather inital readings
-sleep(1)
+time.sleep(1)
 
 while True:
     print("\nTemperature: %0.1f C" % bme280.temperature)


### PR DESCRIPTION
Add attributes for IIR filter, standby period, operation mode,
 and overscan for temperature, pressure and humidity.

Add Enum classes for the overscan, standby, and iir filter values


I started working on this after reading issue #21 .  Admittedly, I haven't tested this (I don't have a BME280), so there may be some silly errors here.  If someone is willing to test, I'd bet happy to fix any bugs. 

Almost all of these changes could be applied to the BMP280 library with very little effort.