### PR TITLE
fix #25 + fix #19 + refactor `pressure` property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 _build
 *.pyc
+*.mpy
 .env
 build*
 bundles

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -344,8 +344,9 @@ class Adafruit_BME280:
         var3 = self._pressure_calib[2] * var1 * var1 / 524288.0
         var1 = (var3 + self._pressure_calib[1] * var1) / 524288.0
         var1 = (1.0 + var1 / 32768.0) * self._pressure_calib[0]
-        if var1 == 0: # avoid exception caused by division by zero (as per Arduino lib)
-            return 0
+        if not var1: # avoid exception caused by division by zero
+            raise ArithmeticError("Invalid result possibly related to error while \
+reading the calibration registers")
         pressure = 1048576.0 - adc
         pressure = ((pressure - var2 / 4096.0) * 6250.0) / var1
         var1 = self._pressure_calib[8] * pressure * pressure / 2147483648.0

--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -414,7 +414,7 @@ reading the calibration registers")
         self._humidity_calib = [0]*6
         self._humidity_calib[0] = self._read_byte(_BME280_REGISTER_DIG_H1)
         coeff = self._read_register(_BME280_REGISTER_DIG_H2, 7)
-        coeff = list(struct.unpack('<hBBBBb', bytes(coeff)))
+        coeff = list(struct.unpack('<hBbBbb', bytes(coeff)))
         self._humidity_calib[1] = float(coeff[0])
         self._humidity_calib[2] = float(coeff[1])
         self._humidity_calib[3] = float((coeff[2] << 4) |  (coeff[3] & 0xF))


### PR DESCRIPTION
* Removed `frozenset()` on `_BME280_IIR_FILTERS`, `_BME280_MODES`, `_BME280_STANDBY_TCS`. Kept as tuples (issue#25).

* Removed useless `if/else` in property `pressure` (was pointed by pylint)
The test against 0 and the `else:` of `if var1:` are redundant.
Kept the test against 0 just like the Arduino lib to align the behavior.

Tested on CPX with CircuitPython 4.0.1 using `bme280_simpletest` and `bme280_normal_mode`
