### PR TITLE
Add relative_humidity property

### DIFF
--- a/adafruit_bme280.py
+++ b/adafruit_bme280.py
@@ -392,6 +392,14 @@ reading the calibration registers"
         return pressure
 
     @property
+    def relative_humidity(self):
+        """
+        The relative humidity in RH %
+        returns None if humidity measurement is disabled
+        """
+        return self.humidity
+
+    @property
     def humidity(self):
         """
         The relative humidity in RH %


### PR DESCRIPTION
Almost all Adafruit libraries with a humidity sensor use `relative_humidity` as the name of the property for sensor humidity:
SHT31D, Si7021, HTU21D, AM2320, HTS221, AHTx0

This PR adds a `relative_humidity` property to BME280 (which simply accesses the `humidity` property) to normalize the API and allow users to remove conditional processing in environments where different humidity sensors may be used.

This has been tested on a BME280 connected to a Feather M4 running CP 5.3.1 and the library's simpletest.py code.