### PR TITLE
aligning_example_code and adding_library_usage_explanation, updating PyPI_packaging_Info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Introduction
     :target: https://github.com/adafruit/Adafruit_CircuitPython_BME280/actions/
     :alt: Build Status
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black
+    :alt: Code Style: Black
+
 I2C and SPI driver for the Bosch BME280 Temperature, Humidity, and Barometric Pressure sensor
 
 Installation and Dependencies
@@ -54,6 +58,29 @@ To install in a virtual environment in your current project:
     source .env/bin/activate
     pip3 install adafruit-circuitpython-bme280
 
+
+Installing to a connected CircuitPython Device
+==============================================
+Some devices, eg. the QT-PY, are very limited in memory. The BME280 library contains
+two variants - basic and advanced - which give different levels of functionality.
+
+Installing the BME280 library could have the following outcomes:
+
+    * It installs successfully and your code runs successfully. Woo-hoo! Continue with
+      your amazing project.
+    * It installs successfully and your code fails to run with a memory allocation
+      error. Try one of the following:
+
+        * If your :data:`code.py` is large, especially if it has lots of comments, you
+          can shrink it into a :data:`.mpy` file instead. See the Adafruit
+          `Learn Guide <https://learn.adafruit.com/Memory-saving-tips-for-CircuitPython/non-volatile-not-enough-disk-space>`_
+          on shrinking your code.
+        * Only use the basic BME280 implementation, and remove the following file:
+          :data:`<CIRCUITPY>/lib/adafruit_bme280/advanced.mpy` where <CIRCUITPY> is the
+          mounted location of your device. Make sure that your code only uses the basic
+          implementation.
+
+
 Usage Example
 =============
 
@@ -61,11 +88,11 @@ Usage Example
 
     import board
     import time
-    from adafruit_bme280 import basic
+    from adafruit_bme280 import basic as adafruit_bme280
 
     # Create sensor object, using the board's default I2C bus.
     i2c = board.I2C()   # uses board.SCL and board.SDA
-    bme280 = basic.Adafruit_BME280_I2C(i2c)
+    bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
     # change this to match the location's pressure (hPa) at sea level
     bme280.sea_level_pressure = 1013.25

--- a/README.rst
+++ b/README.rst
@@ -71,12 +71,12 @@ Installing the BME280 library could have the following outcomes:
     * It installs successfully and your code fails to run with a memory allocation
       error. Try one of the following:
 
-        * If your :data:`code.py` is large, especially if it has lots of comments, you
-          can shrink it into a :data:`.mpy` file instead. See the Adafruit
+        * If your ``code.py`` is large, especially if it has lots of comments, you
+          can shrink it into a ``.mpy`` file instead. See the Adafruit
           `Learn Guide <https://learn.adafruit.com/Memory-saving-tips-for-CircuitPython/non-volatile-not-enough-disk-space>`_
           on shrinking your code.
         * Only use the basic BME280 implementation, and remove the following file:
-          :data:`<CIRCUITPY>/lib/adafruit_bme280/advanced.mpy` where <CIRCUITPY> is the
+          ``<CIRCUITPY>/lib/adafruit_bme280/advanced.mpy`` where <CIRCUITPY> is the
           mounted location of your device. Make sure that your code only uses the basic
           implementation.
 

--- a/adafruit_bme280/advanced.py
+++ b/adafruit_bme280/advanced.py
@@ -282,14 +282,14 @@ class Adafruit_BME280_I2C(Adafruit_BME280_Advanced):
         .. code-block:: python
 
             import board
-            from adafruit_bme280 import advanced
+            import adafruit_bme280.advanced as adafruit_bme280
 
         Once this is done you can define your `board.I2C` object and define your sensor object
 
         .. code-block:: python
 
             i2c = board.I2C()   # uses board.SCL and board.SDA
-            bme280 = advanced.Adafruit_BME280_I2C(i2c)
+            bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
         You need to setup the pressure at sea level
 
@@ -349,7 +349,7 @@ class Adafruit_BME280_SPI(Adafruit_BME280_Advanced):
 
             import board
             from digitalio import DigitalInOut
-            from adafruit_bme280 import advanced
+            import adafruit_bme280.advanced as adafruit_bme280
 
         Once this is done you can define your `board.SPI` object and define your sensor object
 
@@ -357,7 +357,7 @@ class Adafruit_BME280_SPI(Adafruit_BME280_Advanced):
 
             cs = digitalio.DigitalInOut(board.D10)
             spi = board.SPI()
-            bme280 = advanced.Adafruit_BME280_SPI(spi, cs)
+            bme280 = adafruit_bme280.Adafruit_BME280_SPI(spi, cs)
 
         You need to setup the pressure at sea level
 

--- a/adafruit_bme280/basic.py
+++ b/adafruit_bme280/basic.py
@@ -335,14 +335,14 @@ class Adafruit_BME280_I2C(Adafruit_BME280):
         .. code-block:: python
 
             import board
-            from adafruit_bme280 import basic
+            from adafruit_bme280 import basic as adafruit_bme280
 
         Once this is done you can define your `board.I2C` object and define your sensor object
 
         .. code-block:: python
 
             i2c = board.I2C()   # uses board.SCL and board.SDA
-            bme280 = basic.Adafruit_BME280_I2C(i2c)
+            bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
         You need to setup the pressure at sea level
 
@@ -402,7 +402,7 @@ class Adafruit_BME280_SPI(Adafruit_BME280):
 
             import board
             from digitalio import DigitalInOut
-            from adafruit_bme280 import basic
+            from adafruit_bme280 import basic as adafruit_bme280
 
         Once this is done you can define your `board.SPI` object and define your sensor object
 
@@ -410,7 +410,7 @@ class Adafruit_BME280_SPI(Adafruit_BME280):
 
             cs = digitalio.DigitalInOut(board.D10)
             spi = board.SPI()
-            bme280 = basic.Adafruit_BME280_SPI(spi, cs)
+            bme280 = adafruit_bme280.Adafruit_BME280_SPI(spi, cs)
 
         You need to setup the pressure at sea level
 

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
     keywords="adafruit bme280 sensor hardware micropython circuitpython",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=["adafruit_bme280"],
+    packages=["adafruit_bme280"],
 )


### PR DESCRIPTION
Aligning example code and adding library usage explanation in the `readme.rst`

see #53 

This will also change `py_modules` to `packages` in the `conf.py` to resolve #53 in PyPI