### PR TITLE
Provide proxies for I2C and SPI

### DIFF
--- a/adafruit_bme280/advanced.py
+++ b/adafruit_bme280/advanced.py
@@ -142,7 +142,7 @@ class Adafruit_BME280_Advanced(Adafruit_BME280):
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, proxy) -> None:
+    def __init__(self, proxy: typing.Union[I2C_Impl, SPI_Impl]) -> None:
         """Check the BME280 was found, read the coefficients and enable the sensor"""
         self._overscan_humidity = OVERSCAN_X1
         self._overscan_temperature = OVERSCAN_X1

--- a/adafruit_bme280/basic.py
+++ b/adafruit_bme280/basic.py
@@ -34,6 +34,7 @@ import struct
 from time import sleep
 
 from micropython import const
+from protocol import I2C_Impl, SPI_Impl
 
 try:
     import typing  # pylint: disable=unused-import
@@ -88,9 +89,10 @@ class Adafruit_BME280:
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self) -> None:
+    def __init__(self, proxy: typing.Union[I2C_Impl, SPI_Impl]) -> None:
         """Check the BME280 was found, read the coefficients and enable the sensor"""
         # Check device ID.
+        self._proxy = proxy
         chip_id = self._read_byte(_BME280_REGISTER_CHIPID)
         if _BME280_CHIPID != chip_id:
             raise RuntimeError("Failed to find BME280! Chip ID 0x%x" % chip_id)
@@ -309,10 +311,10 @@ class Adafruit_BME280:
         return ret
 
     def _read_register(self, register: int, length: int) -> bytearray:
-        raise NotImplementedError()
+        return self._proxy.read_register(register, length)
 
     def _write_register_byte(self, register: int, value: int) -> None:
-        raise NotImplementedError()
+        self._proxy.write_register_byte(register, value)
 
 
 class Adafruit_BME280_I2C(Adafruit_BME280):
@@ -363,24 +365,7 @@ class Adafruit_BME280_I2C(Adafruit_BME280):
     """
 
     def __init__(self, i2c: I2C, address: int = 0x77) -> None:  # BME280_ADDRESS
-        from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
-            i2c_device,
-        )
-
-        self._i2c = i2c_device.I2CDevice(i2c, address)
-        super().__init__()
-
-    def _read_register(self, register: int, length: int) -> bytearray:
-        with self._i2c as i2c:
-            i2c.write(bytes([register & 0xFF]))
-            result = bytearray(length)
-            i2c.readinto(result)
-            return result
-
-    def _write_register_byte(self, register: int, value: int) -> None:
-        with self._i2c as i2c:
-            i2c.write(bytes([register & 0xFF, value & 0xFF]))
-            # print("$%02X <= 0x%02X" % (register, value))
+        super().__init__(I2C_Impl(i2c, address))
 
 
 class Adafruit_BME280_SPI(Adafruit_BME280):
@@ -433,22 +418,4 @@ class Adafruit_BME280_SPI(Adafruit_BME280):
     """
 
     def __init__(self, spi: SPI, cs: DigitalInOut, baudrate: int = 100000) -> None:
-        from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
-            spi_device,
-        )
-
-        self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)
-        super().__init__()
-
-    def _read_register(self, register: int, length: int) -> bytearray:
-        register = (register | 0x80) & 0xFF  # Read single, bit 7 high.
-        with self._spi as spi:
-            spi.write(bytearray([register]))  # pylint: disable=no-member
-            result = bytearray(length)
-            spi.readinto(result)  # pylint: disable=no-member
-            return result
-
-    def _write_register_byte(self, register: int, value: int) -> None:
-        register &= 0x7F  # Write, bit 7 low.
-        with self._spi as spi:
-            spi.write(bytes([register, value & 0xFF]))  # pylint: disable=no-member
+        super().__init__(SPI_Impl(spi, cs, baudrate))

--- a/adafruit_bme280/basic.py
+++ b/adafruit_bme280/basic.py
@@ -34,7 +34,7 @@ import struct
 from time import sleep
 
 from micropython import const
-from protocol import I2C_Impl, SPI_Impl
+from adafruit_bme280.protocol import I2C_Impl, SPI_Impl
 
 try:
     import typing  # pylint: disable=unused-import

--- a/adafruit_bme280/basic.py
+++ b/adafruit_bme280/basic.py
@@ -89,10 +89,10 @@ class Adafruit_BME280:
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, proxy: typing.Union[I2C_Impl, SPI_Impl]) -> None:
+    def __init__(self, bus_implementation: typing.Union[I2C_Impl, SPI_Impl]) -> None:
         """Check the BME280 was found, read the coefficients and enable the sensor"""
         # Check device ID.
-        self._proxy = proxy
+        self._bus_implementation = bus_implementation
         chip_id = self._read_byte(_BME280_REGISTER_CHIPID)
         if _BME280_CHIPID != chip_id:
             raise RuntimeError("Failed to find BME280! Chip ID 0x%x" % chip_id)
@@ -311,10 +311,10 @@ class Adafruit_BME280:
         return ret
 
     def _read_register(self, register: int, length: int) -> bytearray:
-        return self._proxy.read_register(register, length)
+        return self._bus_implementation.read_register(register, length)
 
     def _write_register_byte(self, register: int, value: int) -> None:
-        self._proxy.write_register_byte(register, value)
+        self._bus_implementation.write_register_byte(register, value)
 
 
 class Adafruit_BME280_I2C(Adafruit_BME280):

--- a/adafruit_bme280/protocol.py
+++ b/adafruit_bme280/protocol.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022 Randall Bohn (dexter)
+#
+# SPDX-License-Identifier: MIT
+"Provides the protocol objects for I2C and SPI"
+
+from busio import I2C, SPI
+from digitalio import DigitalInOut
+
+class I2C_Impl:
+    def __init__(self, i2c: I2C, address: int) -> None:
+        from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
+            i2c_device,
+        )
+
+        self._i2c = i2c_device.I2CDevice(i2c, address)
+    
+    def read_register(self, register: int, length: int) -> bytearray:
+        with self._i2c as i2c:
+            i2c.write(bytes([register & 0xFF]))
+            result = bytearray(length)
+            i2c.readinto(result)
+            return result
+    def write_register_byte(self, register: int, value: int) -> None:
+        with self._i2c as i2c:
+            i2c.write(bytes([register & 0xFF, value & 0xFF]))
+
+class SPI_Impl:
+    def __init__(self, spi: SPI, cs: DigitalInOut, baudrate: int = 100000) -> None:
+        from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
+            spi_device,
+        )
+
+        self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)
+
+    def _read_register(self, register: int, length: int) -> bytearray:
+        register = (register | 0x80) & 0xFF  # Read single, bit 7 high.
+        with self._spi as spi:
+            spi.write(bytearray([register]))  # pylint: disable=no-member
+            result = bytearray(length)
+            spi.readinto(result)  # pylint: disable=no-member
+            # print("$%02X => %s" % (register, [hex(i) for i in result]))
+            return result
+
+    def _write_register_byte(self, register: int, value: int) -> None:
+        register &= 0x7F  # Write, bit 7 low.
+        with self._spi as spi:
+            spi.write(bytes([register, value & 0xFF]))  # pylint: disable=no-member

--- a/adafruit_bme280/protocol.py
+++ b/adafruit_bme280/protocol.py
@@ -6,25 +6,34 @@
 from busio import I2C, SPI
 from digitalio import DigitalInOut
 
+
 class I2C_Impl:
+    "Protocol implementation for the I2C bus."
+
     def __init__(self, i2c: I2C, address: int) -> None:
         from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
             i2c_device,
         )
 
         self._i2c = i2c_device.I2CDevice(i2c, address)
-    
+
     def read_register(self, register: int, length: int) -> bytearray:
+        "Read from the device register."
         with self._i2c as i2c:
             i2c.write(bytes([register & 0xFF]))
             result = bytearray(length)
             i2c.readinto(result)
             return result
+
     def write_register_byte(self, register: int, value: int) -> None:
+        "Write to the device register."
         with self._i2c as i2c:
             i2c.write(bytes([register & 0xFF, value & 0xFF]))
 
+
 class SPI_Impl:
+    "Protocol implemenation for the SPI bus."
+
     def __init__(self, spi: SPI, cs: DigitalInOut, baudrate: int = 100000) -> None:
         from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
             spi_device,
@@ -32,7 +41,8 @@ class SPI_Impl:
 
         self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)
 
-    def _read_register(self, register: int, length: int) -> bytearray:
+    def read_register(self, register: int, length: int) -> bytearray:
+        "Read from the device register."
         register = (register | 0x80) & 0xFF  # Read single, bit 7 high.
         with self._spi as spi:
             spi.write(bytearray([register]))  # pylint: disable=no-member
@@ -41,7 +51,8 @@ class SPI_Impl:
             # print("$%02X => %s" % (register, [hex(i) for i in result]))
             return result
 
-    def _write_register_byte(self, register: int, value: int) -> None:
+    def write_register_byte(self, register: int, value: int) -> None:
+        "Write value to the device register."
         register &= 0x7F  # Write, bit 7 low.
         with self._spi as spi:
             spi.write(bytes([register, value & 0xFF]))  # pylint: disable=no-member


### PR DESCRIPTION
basic.Adafruit_BME280 provides a simplified interface to the device.
advanced.Adafruit_BME280 provides additional functionality.

Each of the above classes has subclasses for _I2C and _SPI busses.
The user will instantiate the appropriate subclass based on their connection.
basic.Adafruit_BME280_I2C or basic.Adafruit_BME280_SPI for example.

pylint complains that there is duplicate code between the basic and advanced implementations. The code to instantiate, read, and write to the device 
is duplicated in both implementations.

This pull request provides a single implementation for I2C and for SPI.
To use *_Impl I added a parameter to the __init__ method 
to set the selected implementation class.

Questions:

- Is 'protocol.py' the right name for the file containing the different bus-specific implementations?
- Is there a better name than *_Impl?
- Is this a proxy or perhaps a delegate? The data attribute in Adafruit_BME280 should be named accordingly.

This work was part of the CircuitPythonDay2022 Sprint.